### PR TITLE
replaced SwedenCentral with GermanyWestCentral

### DIFF
--- a/.ado/pipelines/config/variables-values-e2e.yaml
+++ b/.ado/pipelines/config/variables-values-e2e.yaml
@@ -11,7 +11,7 @@ variables:
 # Check which regions are valid. There is a list in /src/infra/README.md
 # If you are planning to run Chaos Studio experiments, make sure the first region in the list does support Azure Chaos Studio. Not all regions do yet
 - name: 'stampLocations'
-  value: '["uksouth","swedencentral"]'
+  value: '["uksouth","germanywestcentral"]'
 
 # Terraform state variables
 - name:  'terraformResourceGroup'


### PR DESCRIPTION
FIX for
Error: creating Account (Subscription: "8d5335cb-c495-4d8c-9ff6-d5a0ff5c3ce3" │ Resource Group Name: "lde2efad5-monitoring-rg"
│ Account Name: "lde2efad5-swedencen-amw"): azuremonitorworkspaces.AzureMonitorWorkspacesClient#Create: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="LocationNotAvailableForResourceType" Message="The provided location 'swedencentral' is not available for resource type 'Microsoft.Monitor/accounts'. List of available regions for the resource type is 'eastus,australiasoutheast,brazilsouth,canadacentral,centralindia,centralus,eastasia,eastus2,germanywestcentral,israelcentral,italynorth,koreacentral,northeurope,norwayeast,southafricanorth,southcentralus,southeastasia,switzerlandnorth,uaenorth,uksouth,westcentralus,westeurope,westus,westus2'." │